### PR TITLE
Änderungen an den Feinheiten

### DIFF
--- a/Feinheiten.qmd
+++ b/Feinheiten.qmd
@@ -6,7 +6,7 @@
 
 - Der Bugpaddler entscheidet die Drehrichtung.
 - Initiation findet gleichzeitig statt.
-- Alle Manöver vorwärts zur Onside/rückwärts zur Offside werden mit einem diagonalen Ziehschlag eingeleitet.
+- Alle Manöver vorwärts zur Onside und rückwärts zur Offside können mit diagonalen Ziehschlägen eingeleitet werden.
 - Alle Manöver vorwärts zur Offside/rückwärts zur Onside werden mit einem kurzen Bogenschlag (beim führenden Paddler) und überkorrigierten J-Schlag (beim folgenden Paddler) eingeleitet. 
 - Side slips haben keine Einleitung und können daran erkannt werden.
 - Aus Side slips kann man aber auch wunderbar direkt in Manöver übergehen. Wann in welche Richtung weggedreht wird, ist dann ein wenig Gefühlssache, die Kantung sollte in dem Fall dann aber nicht gewechselt werden, sondern nur verstärkt werden, sonst entsteht zu viel Unruhe.

--- a/Feinheiten.qmd
+++ b/Feinheiten.qmd
@@ -1,5 +1,11 @@
 # Feinabstimmung {.unnumbered}
 
+## Definitionen und Erklärungen
+
+- Führendes und folgendes Bootsende
+- Führender und folgender Paddler
+- Aktive Paddelseite
+
 ## Allgemeingültige Dinge
 
 ### Initiation
@@ -7,23 +13,22 @@
 - Der Bugpaddler entscheidet die Drehrichtung.
 - Initiation findet gleichzeitig statt.
 - Alle Manöver vorwärts zur Onside und rückwärts zur Offside können mit diagonalen Ziehschlägen eingeleitet werden.
-- Alle Manöver vorwärts zur Offside/rückwärts zur Onside werden mit einem kurzen Bogenschlag (beim führenden Paddler) und überkorrigierten J-Schlag (beim folgenden Paddler) eingeleitet. 
+- Alle Manöver vorwärts zur Offside und rückwärts zur Onside können mit einem kurzen Bogenschlag (beim führenden Paddler) und überkorrigierten J-Schlag (beim folgenden Paddler) eingeleitet werden. 
 - Side slips haben keine Einleitung und können daran erkannt werden.
 - Aus Side slips kann man aber auch wunderbar direkt in Manöver übergehen. Wann in welche Richtung weggedreht wird, ist dann ein wenig Gefühlssache, die Kantung sollte in dem Fall dann aber nicht gewechselt werden, sondern nur verstärkt werden, sonst entsteht zu viel Unruhe.
 
 
 ### Placement
 
-- aktive Paddelseite
-  - führender Paddler
-    - bleibt immer die gleich Seite
-    - Winkel variiert zwischen neutraler Haltung und kompletter Bremsung
-  - folgender Paddler
-    - variabel, kann wechseln
-    - beeinflusst damit den Kurvenverlauf und damit in welche Richtung es weitergeht
-       - mehr Schleudern: Fahrtrichtung ändert sich (Formulierung!!!); Momentum bleibt in der ursprünglichen Bewegungsrichtung erhalten (Ausrichtung des Boots ändert sich im Verhältnis zur Fahrt)
-       - kein Schleudern: ursprüngliche Fahrt (vorwärts vs. rückwärts) bleibt erhalten; Momentum bleibt auf der Bewegungsachse des Boots erhalten (Ausrichtung des Boots ändert sich nicht)
-    - beginnt in der Regel damit, das Schleudern abzufangen und die Fahrt zu stabiliseren (dies kann eine variable Länge haben und im Extremfall (z.B. Christie) komplett wegfallen)
+- führender Paddler
+  - Die aktive Paddelseite bleibt während des Placements die gleiche
+  - Der Winkel kann zwischen neutraler Haltung und kompletter Bremsung variiert werden.
+- folgender Paddler
+  - Die aktive Paddelseite ist variabel. Je nach gewünschtem Manöververlauf kann die aktive Seite mehrfach wechseln. 
+  - Beeinflusst damit entscheidend den Charakter des Manövers:
+    - Kann das Ausbrechen des folgenden Bootsendes verhinden und das Boot auf seiner Kurvenfahrt stabilisieren (mit einem Christie nicht möglich). Das Momentum bleibt entlang der Längsachse des Bootes erhalten.
+    - Kann das Ausbrechen des folgenden Bootsendes zulassen oder unterstützen und damit eine Drehung des Bootes begünstigen. Aus einem Vorwärtsmanöver kann die Fahrt dann rückwärts, aber in gleicher Fahrtrichtung, forgesetzt werden oder umgekehrt. Das Moment bleibt in der ursprünglichen Bewegungsrichtung erhalten. 
+
 
 ### Kantung -- rein
 
@@ -31,18 +36,17 @@
 
 ### Conclusion
 
-- Der Paddler mit dem weiteren Weg zur Conclusion bestimmt das Timing, es sei denn er kann vom anderen Paddler nicht gesehen werden.
+- Der Paddler mit dem weiteren Weg zur Conclusion bestimmt den Beginn, es sei denn er kann vom anderen Paddler nicht gesehen werden.
 - Bei Rückwärtsmanövern gibt im Idealfall der Heckpaddler das Timing vor, weil er die Bootsdrehung besser beurteilen kann. Das ist allerdings nicht in allen Manövern gut machbar, weil der Bugpaddler nicht immer ausreichende Sicht nach hinten hat.
-- Eine versetzte Conclusion ergibt Sinn, wenn der Weg von Conclusion zum nächsten Schlag für beide unterschiedlich lang ist
-- Gründe für eine versetzte Conclusion
-  - gleichzeitiges Ankommen beim nächsten Schlag
-  - es passt auch immer mit paralleler Conclusion, aber versetzt macht es runder
-- Cross-Manöver zur Offside (Axle, Post) haben eine versetzte Conclusion
-  - (Heckpaddler nicht Cross:) vorne beginnt die Conclusion (Formulierung für Normalzustand)
-  - Heckpaddler Cross: hinten beginnt die Conclusion (Cross Forward schließt sich an, s.u. Weiterfahrt)
-- Stern Cross-Manöver zur Onside (Axle, Post) haben eine versetzte Conclusion, sofern der Bugpaddler kein Cross Placement macht (s.u. Weiterfahrt)
-  - Heckpaddler beginnt (kann man von vorne halbwegs sehen)
-  - nicht bei Stern Cross Manövern mit Fronpaddler Cross, weil der Cross Rückwärtsschlag nicht gut geht und man deshalb direkt rüber geht, der Weg ist dann für beide weit und man macht die Conclusion parallel
+- Eine versetzte Conclusion ergibt Sinn, wenn der Weg von der Conclusion zum nächsten Schlag für beide unterschiedlich lang ist, der nächste Schlag aber zeitgleich gemacht werden soll.
+- Eine versetzte Conclusion ergibt häufig einen runderen Ablauf, aber eine parallel ausgeführte Conclusion funktioniert ebenfalls.
+- Cross Axle und Cross Post haben eine versetzte Conclusion
+  - Der Bugpaddler beginnt die Conclusion
+  - Ausnahme: Macht der Heckpaddler ein Cross-Placement beginnt er die Conclusion (weiterer Weg, s.o.) (Cross Forward schließt sich an, s.u. Weiterfahrt).
+- Stern Cross Axle und Stern Cross Post haben eine versetzte Conclusion.
+  - Der Heckpaddler beginnt die Conclusion (kann vom Bugpaddler halbwegs gesehen werden)
+  - Ausnahme: Macht der Bugpaddler ein Cross Placement, wird die Conclusion parallel ausgeführt. Ein Cross Rückwärtsschlag ist wenig praxistauglich. Damit haben beide Paddler einen langen Weg zum nächsten Catch und die parallele Conclusion bietet sich an.
+
 
 ### Kantung -- raus
 
@@ -57,9 +61,9 @@
 
 ### Weiterfahrt
 
-- Wenn beide Paddler ein Cross-Placement machen, wird eine Vorwärtsweiterfahrt mit Cross Forwards begonnen. (Rückwärts gilt dies nicht, weil ein Cross Rückwärtsschlag unbequem ist.)
+- Wenn beide Paddler ein Cross-Placement machen, ist es günstig die Vorwärtsweiterfahrt mit Cross Forwards zu beginnen. (Rückwärts gilt dies nicht, weil ein Cross Rückwärtsschlag unbequem ist.)
 - Die Länge der Manöver ist Cross und Nicht-Cross meist gleich.
-- Ggf. beim ersten Vorwärtsschlag nach Manöver auch im Bug die Drehung etwas korrigieren
+- Ggf. beim ersten Vorwärtsschlag nach Manöver auch im Bug die Drehung etwas korrigieren.
 
 
 <!-- - Cross-Placement im Bug: Im Heck kann die Conclusion verzögert gemacht werden, um dem Bug-Paddler Zeit zu geben, das Paddel wieder auf die Onside zu bringen (wenn kein Cross Vorwärtsschlag anschließt). -->

--- a/intro.qmd
+++ b/intro.qmd
@@ -1,16 +1,17 @@
 # Allgemeine Gedanken {.unnumbered}
 
 ## Placements
-
+<!-- Ich denke, dass der folgende Absatz komplett ersetzt werden kann durch die Texte, die bei den "Allgemeingültigen Dingen" stehen. -->
 klassisch:
 
 - vorwärts: Bugpaddler
 - rückwärts: Heckpaddler
 - der jeweils andere kann den Charakter des Manövers durch stationäres Schneiden oder stationäre Drück- oder Ziehschläge beeinflussen und hat verschiedene Möglichkeiten (ggf. parallele Bewegungen bevorzugen)
+<!-- Vom folgenden Satz bin ich immer noch nicht überzeugt. Das Placement hinter dem Drehpunkt ist möglich, aber als alleiniges Placement nicht sehr wirksam, wenn das Boot ungünstig getrimmt ist (wie in unserem Fall). Ich würde eher davon ausgehen, dass beide ein Placement machen. -->
 - wie auch im Solo, sollte aber auch eine Platzierung auf der jeweils anderen Seite des Drehpunktes möglich sein, dann wären die Rollen genau getauscht und der zweite stört nicht. Soweit ich das sehe, ist das aber noch namenlos.
 
 Erweiterung: 
-
+<!-- Das hier ist dann irgendwie doppelt. -->
 - der folgende Paddler kann durch Kraft auf dem Paddel die Stärke des Schleuderns steuern also nicht nur neutral sein
 - darauf aufbauend kann der folgende Paddler im Grunde auch das Placement machen und der führende Paddler die Kurve steuern
   - beim stern axle/post vom Bugpaddler gefahren, hätte der dann zum Beispiel Kraft innen auf dem Paddel und das Paddel in Fahrtrichtung vom Boot wegzeigend
@@ -30,6 +31,6 @@ Erweiterung:
 - für den, der das Manöver macht, sind Bewegungen festgelegt (die einzige Variation ist eine Cross Einleitung und ggf. Variation im Abschluss, wenn man danach was anderes machen will), der andere hat wesentlich mehr Variationsspielraum. Auch dort scheint sich aber eine Struktur zu ergeben mit immer ähnlichen Möglichkeiten (so wahnsinnig viele Möglichkeiten gibt es ja auch nicht). Entscheidend ist hier im Grunde lediglich die Kantung und Drehrichtung, nicht das Manöver. Je nachdem was man möchte, kann man das Manöver parallel zum anderen Paddler aufbauen.
 
 ## Begriffe
-
+<!-- Sollten wir mit in einen Bereich "Definitionen und Erklärungen" packen. -->
 - Cross (Kreuz) auf Englisch belassen für einheitliche Bezeichnungen = übergegriffener Schlag, Paddel auf die Nicht-Paddelseite bewegen
 - Onside = Paddelseite des Bug, Offside = Paddelseite des Heck


### PR DESCRIPTION
Ich habe viele Kleinigkeiten an den allgemeingültigen Dingen angepasst. 

Ich würde vorschlagen die Feinheiten.qmd aufzuteilen. Die Allgemeingültigen Dinge gehören eigentlich in eine eigene Datei, die meiner Meinung nach in der Übersicht noch vor den einzelnen Manövern stehen müsste. 

Für die nonverbale Kommunikation, die Fragen und die Musik sind ebenfalls eigene Dateien sinnvoll, um die Übersichtlichkeit zu erhöhen.